### PR TITLE
Make fmt::Display for Isbn10 / Isbn13 4x faster

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,15 +420,11 @@ impl fmt::Display for Isbn13 {
 
 impl From<Isbn10> for Isbn13 {
     fn from(isbn10: Isbn10) -> Isbn13 {
-        let mut v = ArrayVec::<[u8; 13]>::new();
-        v.extend([9, 7, 8].iter().cloned());
-        v.extend(isbn10.digits[..9].iter().cloned());
-        let c = Isbn13::calculate_check_digit(&v);
-        let d = isbn10.digits;
-        Isbn13::new(
-            9, 7, 8, d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], c,
-        )
-        .unwrap()
+        let mut a = [0; 13];
+        a[..3].clone_from_slice(&[9, 7, 8]);
+        a[3..12].clone_from_slice(&isbn10.digits[0..9]);
+        a[12] = Isbn13::calculate_check_digit(&a);
+        Isbn13 { digits: a }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,13 +265,28 @@ impl Isbn10 {
 
 impl fmt::Display for Isbn10 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for x in &self.digits {
-            match x {
-                10 => write!(f, "X")?,
-                _ => write!(f, "{}", x)?,
+        fn convert(d: u8) -> u8 {
+            if d < 10 {
+                d + 48
+            } else {
+                'X' as u8
             }
         }
-        Ok(())
+        let s = self.digits;
+        let s = [
+            convert(s[0]),
+            convert(s[1]),
+            convert(s[2]),
+            convert(s[3]),
+            convert(s[4]),
+            convert(s[5]),
+            convert(s[6]),
+            convert(s[7]),
+            convert(s[8]),
+            convert(s[9]),
+        ];
+        let s = ArrayString::from_byte_string(&s).unwrap();
+        write!(f, "{}", s)
     }
 }
 
@@ -402,10 +417,32 @@ impl Isbn13 {
 
 impl fmt::Display for Isbn13 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        for x in &self.digits {
-            write!(f, "{}", x)?;
+        fn convert(d: u8) -> u8 {
+            if d < 10 {
+                d + 48
+            } else {
+                'X' as u8
+            }
         }
-        Ok(())
+        let s = self.digits;
+        let s = [
+            convert(s[0]),
+            convert(s[1]),
+            convert(s[2]),
+            convert(s[3]),
+            convert(s[4]),
+            convert(s[5]),
+            convert(s[6]),
+            convert(s[7]),
+            convert(s[8]),
+            convert(s[9]),
+            convert(s[10]),
+            convert(s[11]),
+            convert(s[12]),
+        ];
+        let s = ArrayString::from_byte_string(&s).unwrap();
+
+        write!(f, "{}", s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,31 +265,16 @@ impl Isbn10 {
 
 impl fmt::Display for Isbn10 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn convert(d: u8) -> u8 {
+        fn convert(d: u8) -> char {
             if d < 10 {
-                d + 48
+                ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'][d as usize]
             } else {
-                'X' as u8
+                'X'
             }
         }
-        let s = self.digits;
-        let s = [
-            convert(s[0]),
-            convert(s[1]),
-            convert(s[2]),
-            convert(s[3]),
-            convert(s[4]),
-            convert(s[5]),
-            convert(s[6]),
-            convert(s[7]),
-            convert(s[8]),
-            convert(s[9]),
-        ];
-        if let Ok(s) = ArrayString::from_byte_string(&s) {
-            write!(f, "{}", s)
-        } else {
-            Ok(())
-        }
+        let mut s = ArrayString::<[u8; 10]>::new();
+        self.digits.iter().for_each(|&c| s.push(convert(c)));
+        write!(f, "{}", s)
     }
 }
 
@@ -420,34 +405,16 @@ impl Isbn13 {
 
 impl fmt::Display for Isbn13 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fn convert(d: u8) -> u8 {
+        fn convert(d: u8) -> char {
             if d < 10 {
-                d + 48
+                ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'][d as usize]
             } else {
-                'X' as u8
+                'X'
             }
         }
-        let s = self.digits;
-        let s = [
-            convert(s[0]),
-            convert(s[1]),
-            convert(s[2]),
-            convert(s[3]),
-            convert(s[4]),
-            convert(s[5]),
-            convert(s[6]),
-            convert(s[7]),
-            convert(s[8]),
-            convert(s[9]),
-            convert(s[10]),
-            convert(s[11]),
-            convert(s[12]),
-        ];
-        if let Ok(s) = ArrayString::from_byte_string(&s) {
-            write!(f, "{}", s)
-        } else {
-            Ok(())
-        }
+        let mut s = ArrayString::<[u8; 13]>::new();
+        self.digits.iter().for_each(|&c| s.push(convert(c)));
+        write!(f, "{}", s)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,8 +285,11 @@ impl fmt::Display for Isbn10 {
             convert(s[8]),
             convert(s[9]),
         ];
-        let s = ArrayString::from_byte_string(&s).unwrap();
-        write!(f, "{}", s)
+        if let Ok(s) = ArrayString::from_byte_string(&s) {
+            write!(f, "{}", s)
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -440,9 +443,11 @@ impl fmt::Display for Isbn13 {
             convert(s[11]),
             convert(s[12]),
         ];
-        let s = ArrayString::from_byte_string(&s).unwrap();
-
-        write!(f, "{}", s)
+        if let Ok(s) = ArrayString::from_byte_string(&s) {
+            write!(f, "{}", s)
+        } else {
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
Instead of writing each digit independently, we can collect them into an ArrayString and write all at once, reducing the number of write! calls significantly, and preventing all intermediate errors.

The times are as follows:

Before:
```
test tests::test_isbn10_to_str ... bench:         358 ns/iter (+/- 19)
test tests::test_isbn13_to_str ... bench:         409 ns/iter (+/- 27)
```

After:
```
test tests::test_isbn10_to_str ... bench:         100 ns/iter (+/- 1)
test tests::test_isbn13_to_str ... bench:         109 ns/iter (+/- 9)
```