### PR TITLE
Don't panic on invalid ISBN strings.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,7 +492,7 @@ impl Parser {
                 '-' | ' ' => {},
                 'X' => if digits.len() == 9 {
                     has_x = true;
-                    digits.try_push(10)?;
+                    digits.push(10);
                 } else {
                     return Err(IsbnError::InvalidDigit);
                 },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,14 +485,26 @@ struct Parser {
 impl Parser {
     pub fn new(s: &str) -> Result<Parser, IsbnError> {
         let mut digits = ArrayVec::new();
+        let mut has_x = false;
+
         for c in s.chars() {
             match c {
                 '-' | ' ' => {},
-                'X' => digits.try_push(10)?,
-                '0'..='9' => digits.try_push(c.to_digit(10).unwrap() as u8)?,
+                'X' => if digits.len() == 9 {
+                    has_x = true;
+                    digits.try_push(10)?;
+                } else {
+                    return Err(IsbnError::InvalidDigit);
+                },
+                '0'..='9' => if has_x {
+                    return Err(IsbnError::InvalidDigit);
+                } else {
+                    digits.try_push(c.to_digit(10).unwrap() as u8)?
+                },
                 _ => return Err(IsbnError::InvalidDigit),
             }
         }
+
         Ok(Parser { digits })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,12 @@ impl fmt::Display for Isbn10 {
 impl FromStr for Isbn10 {
     type Err = IsbnError;
     fn from_str(s: &str) -> Result<Isbn10, IsbnError> {
-        Parser::new(s)?.read_isbn10()
+        let mut p = Parser::new(s)?;
+        if p.digits.len() != 10 {
+            Err(IsbnError::InvalidLength)
+        } else {
+            p.read_isbn10()
+        }
     }
 }
 
@@ -426,7 +431,12 @@ impl From<Isbn10> for Isbn13 {
 impl FromStr for Isbn13 {
     type Err = IsbnError;
     fn from_str(s: &str) -> Result<Isbn13, IsbnError> {
-        Parser::new(s)?.read_isbn13()
+        let mut p = Parser::new(s)?;
+        if p.digits.len() != 13 {
+            Err(IsbnError::InvalidLength)
+        } else {
+            p.read_isbn13()
+        }
     }
 }
 
@@ -531,7 +541,7 @@ impl Parser {
         let check_digit = Isbn10::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
             let mut a = [0; 10];
-            a.clone_from_slice(&self.digits[..10]);
+            a.clone_from_slice(&self.digits);
             Ok(Isbn10 { digits: a })
         } else {
             Err(IsbnError::InvalidDigit)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -508,7 +508,7 @@ impl Parser {
         let check_digit = Isbn13::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
             let mut a = [0u8; 13];
-            a.clone_from_slice(&self.digits);
+            a.clone_from_slice(&self.digits[..13]);
             Ok(Isbn13 { digits: a })
         } else {
             Err(IsbnError::InvalidDigit)
@@ -519,7 +519,7 @@ impl Parser {
         let check_digit = Isbn10::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
             let mut a = [0; 10];
-            a.clone_from_slice(&self.digits[0..10]);
+            a.clone_from_slice(&self.digits[..10]);
             Ok(Isbn10 { digits: a })
         } else {
             Err(IsbnError::InvalidDigit)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -507,10 +507,9 @@ impl Parser {
     fn read_isbn13(&mut self) -> Result<Isbn13, IsbnError> {
         let check_digit = Isbn13::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
-            let d = &self.digits;
-            Isbn13::new(
-                d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9], d[10], d[11], d[12],
-            )
+            let mut a = [0u8; 13];
+            a.clone_from_slice(&self.digits);
+            Ok(Isbn13 { digits: a })
         } else {
             Err(IsbnError::InvalidDigit)
         }
@@ -519,8 +518,9 @@ impl Parser {
     fn read_isbn10(&mut self) -> Result<Isbn10, IsbnError> {
         let check_digit = Isbn10::calculate_check_digit(&self.digits);
         if check_digit == *self.digits.last().unwrap() {
-            let d = &self.digits;
-            Isbn10::new(d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7], d[8], d[9])
+            let mut a = [0; 10];
+            a.clone_from_slice(&self.digits[0..10]);
+            Ok(Isbn10 { digits: a })
         } else {
             Err(IsbnError::InvalidDigit)
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use core::fmt;
 use core::num::ParseIntError;
 use core::str::FromStr;
 
-use arrayvec::{ArrayString, ArrayVec};
+use arrayvec::{ArrayString, ArrayVec, CapacityError};
 
 pub type IsbnResult<T> = Result<T, IsbnError>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -590,5 +590,17 @@ mod tests {
         assert!(Isbn::from_str("").is_err());
         assert!(Isbn::from_str("01234567890123456789").is_err());
         assert!(Isbn::from_str("ⱧňᚥɂᛢĞžᚪ©ᛟƚ¶G").is_err());
+
+        assert!(Isbn10::from_str("").is_err());
+        assert!(Isbn10::from_str("01234567890").is_err());
+        assert!(Isbn10::from_str("01234567X9").is_err());
+        assert!(Isbn10::from_str("012345678").is_err());
+
+        assert!(Isbn13::from_str("").is_err());
+        assert!(Isbn13::from_str("012345678901X").is_err());
+        assert!(Isbn13::from_str("01234567890X2").is_err());
+        assert!(Isbn13::from_str("012345678").is_err());
+        assert!(Isbn13::from_str("0123456789012345").is_err());
+
     }
 }


### PR DESCRIPTION
Parser::new(), Isbn::from_str, Isbn10::from_str, and Isbn13::from_str can panic if their input is too short, or too long, and they can create ISBNs from garbage data, and Isbn10::from_str can accept ISBNs with more than 10 digits.

Parser::new() should return a Result<Parser, IsbnError> instead, since it shouldn't parse bad data (arguably, Parser::new() doesn't even need to be public). With this PR, Parser::new() will only ever accept a valid ISBN (eg. 10 or 13 digits, and only have an 'X' if the ISBN is 10 digits long and the 'X' is on the 10th digit), and it will not panic on strings with > 13 digits, and it will not produce garbage data from strings which aren't ISBNs.

Isbn, Isbn10::from_str, Isbn13::from_str will no longer panic if they do not have enough digits or have too many digits.

We can also optimize the read_isbn methods by using IsbnXX { digits: x } instead of IsbnXX::new(), since Parser will only ever hold digits which have already been checked to in the correct range for that particular Isbn.

This PR also adds unit tests to make sure that Parse::new() errors when appropriate.

As an additionally note, since merging this change would be a breaking (but very necessary change, since it prevents panics), it may also be a good idea to reconsider taking individual digits for the Isbn10 and Isbn13 constructors so that they take an array in the first place - breaking both things at once would be better than breaking them in separate releases. 

A few reasons why an array as input would be better: 
- the digits are already converted to an array internally, and this prevents possible additional copies when taking an old array.
- it only adds two extra characters for people using the old API (eg. go from (1, .., 10) to ([1, .., 10])
- it dramatically reduces the amount of typing required for everything else (eg. creating new ISBN's is much easier)

This PR addresses #6 