### PR TITLE
Remove Serialize/Deserialize for IsbnRef

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,6 @@ impl Isbn {
 /// assert_eq!("978-1-4920-6766-5".parse(), Ok(isbn_13));
 /// ```
 #[derive(Debug, PartialEq, Clone, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize, Deserialize))]
 pub enum IsbnRef<'a> {
     _10(&'a Isbn10),
     _13(&'a Isbn13),


### PR DESCRIPTION
Fix #16, as it seems serde can't deserialize a ref to a arbitrary struct:

https://users.rust-lang.org/t/serde-enum-variants-with-reference-arguments-fail-to-compile/28705