### PR TITLE
Make CI green, as indexmap requires a newer rust

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        rust: [stable, nightly, beta, 1.40.0]
+        rust: [stable, nightly, beta, 1.56.0]
     steps:
     - uses: actions/checkout@v2
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Jihyeok Seo <ji@hyeok.org>", "Philippe Solodov <solop1906@gmail.com>
 description = "A library for handling ISBNs."
 license = "MIT"
 repository = "https://github.com/limeburst/isbn-rs"
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 codegen = "0.1"


### PR DESCRIPTION
And the 1.40 toolchain for macos seems to fail due to missing target.