### PR TITLE
Fix clippy warnings to reduce noise

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,4 +60,4 @@ jobs:
         toolchain: stable
         override: true
     - name: Run clippy
-      run: rustup component add clippy && cargo clippy --features runtime-ranges,serialize
+      run: rustup component add clippy && cargo clippy --features runtime-ranges,serialize -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ description = "A library for handling ISBNs."
 license = "MIT"
 repository = "https://github.com/limeburst/isbn-rs"
 edition = "2021"
+rust-version = "1.56.0" 
 
 [build-dependencies]
 codegen = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -9,8 +9,7 @@ use roxmltree::{Document, Node};
 const ALLOW_LINTS: &str = r###"
 #[allow(clippy::unreadable_literal)]
 #[allow(clippy::match_same_arms)]
-#[allow(clippy::too_many_lines)]
-"###;
+#[allow(clippy::too_many_lines)]"###;
 
 /// EAN.UCC prefix or registration group.
 struct Group {
@@ -173,8 +172,7 @@ fn main() {
     let mut f = File::open("./isbn-ranges/RangeMessage.xml").unwrap();
     let mut text = String::new();
     f.read_to_string(&mut text).unwrap();
-    let mut options = roxmltree::ParsingOptions::default();
-    options.allow_dtd = true;
+    let options = roxmltree::ParsingOptions { allow_dtd: true };
     let range_message = Document::parse_with_options(&text, options).unwrap();
     let ean_ucc_groups = range_message
         .descendants()

--- a/src/range.rs
+++ b/src/range.rs
@@ -74,7 +74,7 @@ fn read_xml_tag<B: BufRead>(
     };
     buf.clear();
     let res = match reader.read_event(buf)? {
-        Event::Text(e) => e.unescape_and_decode(&reader)?,
+        Event::Text(e) => e.unescape_and_decode(reader)?,
         _ => return Err(IsbnRangeError::WrongXmlBody),
     };
     match reader.read_event(buf)? {
@@ -154,7 +154,8 @@ impl Segment {
                     if length.len() != 1 {
                         return Err(IsbnRangeError::BadLengthString);
                     }
-                    let length = usize::from_str_radix(&length, 10)
+                    let length = length
+                        .parse::<usize>()
                         .map_err(|_| IsbnRangeError::BadLengthString)?;
                     if length > 7 {
                         return Err(IsbnRangeError::LengthTooLarge);
@@ -488,7 +489,7 @@ impl IsbnRange {
                 isbn.group_prefix(registration_group_segment_length),
             ))
             .ok_or(IsbnError::InvalidGroup)?;
-        Ok(&segment
+        Ok(segment
             .group(isbn.segment(registration_group_segment_length))?
             .name)
     }


### PR DESCRIPTION
The CI will also be red on all warnings to avoid introducing regressions